### PR TITLE
Fix pip install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ participate in the beta program, contact cadcad [at] block [dot] science.
 Replace `<TOKEN>` in the installation URL below.
 ```bash
 pip3 install pandas pathos fn funcy tabulate 
-pip3 install cadCAD --extra-index-url https://<TOKEN>@repo.fury.io/blockscience/
+pip3 install cadCAD --extra-index-url https://<TOKEN>:@repo.fury.io/blockscience/
 ```
 
 #### 1. [Configure System Model](https://github.com/BlockScience/cadCAD-Tutorials/blob/master/documentation/Simulation_Configuration.md)


### PR DESCRIPTION
The gemfury url instructions in the readme are missing a colon (:) after the `<TOKEN>`, and as a result, the instructions in this readme were not working for me.

I found the solution by reading gemfury's documentation [here](https://gemfury.com/help/pypi-server).

This pr fixes the instructions in the README.md